### PR TITLE
Fix the query for postgresql

### DIFF
--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -304,14 +304,10 @@ module StarWars
 
     connection :newestBasesGroupedByFaction, BaseType.connection_type do
       resolve ->(obj, args, ctx) {
-        # Base.order('sum(faction_id) desc').group(:faction_id)
-
         Base
           .having('id in (select max(id) from bases group by faction_id)')
           .order(faction_id: :desc)
           .group(:id)
-
-        # Base.joins('inner join (select faction_id, sum(faction_id) as faction_score from bases group by faction_id) abc on abc.faction_id = bases.faction_id').having('id in (select max(id) from bases group by faction_id)').order('abc.faction_score desc').group('id, faction_score')
       }
     end
 

--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -304,7 +304,14 @@ module StarWars
 
     connection :newestBasesGroupedByFaction, BaseType.connection_type do
       resolve ->(obj, args, ctx) {
-        Base.order('sum(faction_id) desc').group(:faction_id)
+        # Base.order('sum(faction_id) desc').group(:faction_id)
+
+        Base
+          .having('id in (select max(id) from bases group by faction_id)')
+          .order(faction_id: :desc)
+          .group(:id)
+
+        # Base.joins('inner join (select faction_id, sum(faction_id) as faction_score from bases group by faction_id) abc on abc.faction_id = bases.faction_id').having('id in (select max(id) from bases group by faction_id)').order('abc.faction_score desc').group('id, faction_score')
       }
     end
 


### PR DESCRIPTION
Two solutions for you! They both seem to work in PostgreSQL, and in the default backend (SQLite?). I think the uncommented one is slightly cleaner, but the latter is closer to the original code.

Also note that `sum(faction_id)` is used, not `count(faction_id)`. Meaning that, seeing as both factions have exactly 3 bases, the values will be "3" and "6" respectively, not "3" and "3". Weirdness.