### PR TITLE
Provide order argument as string

### DIFF
--- a/spec/support/star_wars/schema.rb
+++ b/spec/support/star_wars/schema.rb
@@ -306,8 +306,8 @@ module StarWars
       resolve ->(obj, args, ctx) {
         Base
           .having('id in (select max(id) from bases group by faction_id)')
-          .order(faction_id: :desc)
           .group(:id)
+          .order('faction_id desc')
       }
     end
 


### PR DESCRIPTION
Apparently Rails 3.2 can't deal with the arguments being symbols. This causes
Rails to escape the argument.


```
[9] pry(#<GraphQL::Define::DefinedObjectProxy>)> Base.having('id in (select max(id) from bases group by faction_id)').group(:id).order(faction_id: :desc).to_sql
=> "SELECT \"bases\".* FROM \"bases\"  GROUP BY id HAVING id in (select max(id) from bases group by faction_id) ORDER BY '---\n:faction_id: :desc\n'"
```

Note the newlines and the `---`.